### PR TITLE
Use object-style PostCSS config

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,8 @@
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- switch the PostCSS configuration to the object-style plugin map that Next.js expects, enabling Tailwind CSS and Autoprefixer via empty option objects

## Testing
- npm run build *(fails: repository does not include a package.json, so npm cannot run the script)*

------
https://chatgpt.com/codex/tasks/task_e_68cf151db254832199c6261749bd0fee